### PR TITLE
fix: support multi-word languages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export default function rehypePrettyCode(options = {}) {
         node.children[0].properties.className[0].startsWith('language-')
       ) {
         const codeNode = node.children[0].children[0];
-        const lang = node.children[0].properties.className[0].split('-')[1];
+        const lang = node.children[0].properties.className[0].replace('language-', '');
         const meta =
           node.children[0].data?.meta ?? node.children[0].properties.metastring;
         const lineNumbers = meta

--- a/test/fixtures/multiWordLanguage.md
+++ b/test/fixtures/multiWordLanguage.md
@@ -1,0 +1,9 @@
+# Hyphenated language
+
+```git-rebase
+pick e0662b2 Improve a11y of the logo image
+fixup 41aac9e fixup! e0662b2
+pick d3942e9 Use SVG format for the logo
+fixup f5409b6 fixup! d3942e9
+pick 5dae451 Link logo to the site root
+```

--- a/test/results/multiWordLanguage.html
+++ b/test/results/multiWordLanguage.html
@@ -1,0 +1,30 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    background: black;
+    display: grid;
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  .highlighted, .word {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+</style>
+<h1>Hyphenated language</h1>
+<span data-rehype-pretty-code-fragment="">
+  <pre><code data-language="git-rebase" data-theme="default"><span class="line"><span style="color: #79C0FF">pick</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">e0662b2</span><span style="color: #C9D1D9"> Improve a11y of the logo image</span></span>
+<span class="line"><span style="color: #79C0FF">fixup</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">41aac9e</span><span style="color: #C9D1D9"> fixup! e0662b2</span></span>
+<span class="line"><span style="color: #79C0FF">pick</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">d3942e9</span><span style="color: #C9D1D9"> Use SVG format for the logo</span></span>
+<span class="line"><span style="color: #79C0FF">fixup</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">f5409b6</span><span style="color: #C9D1D9"> fixup! d3942e9</span></span>
+<span class="line"><span style="color: #79C0FF">pick</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">5dae451</span><span style="color: #C9D1D9"> Link logo to the site root</span></span></code></pre>
+</span>


### PR DESCRIPTION
There are some languages supported by shiki that have multiple words, separated by hyphens, like `git-rebase` and `vue-html`.

https://github.com/shikijs/shiki/blob/main/docs/languages.md
