### PR TITLE
feat: add custom highlighter option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import {Highlighter} from 'shiki';
+
 type theme = JSON | string;
 
 export type Options = {
@@ -7,6 +9,7 @@ export type Options = {
   onVisitLine(node: any): void;
   onVisitHighlightedLine(node: any): void;
   onVisitHighlightedWord(node: any): void;
+  getHighlighter?: (options: Pick<Options, 'theme'>) => Highlighter;
 };
 
 declare const rehypePrettyCode: (options?: Partial<Options>) => any;

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export default function rehypePrettyCode(options = {}) {
     onVisitLine = () => {},
     onVisitHighlightedLine = () => {},
     onVisitHighlightedWord = () => {},
+    getHighlighter = shiki.getHighlighter,
   } = options;
 
   return async (tree) => {
@@ -45,13 +46,13 @@ export default function rehypePrettyCode(options = {}) {
       theme?.hasOwnProperty('tokenColors')
     ) {
       if (!highlighterCache.has('default')) {
-        highlighterCache.set('default', shiki.getHighlighter({theme}));
+        highlighterCache.set('default', getHighlighter({theme}));
       }
     } else if (typeof theme === 'object') {
       // color mode object
       for (const [mode, value] of Object.entries(theme)) {
         if (!highlighterCache.has(mode)) {
-          highlighterCache.set(mode, shiki.getHighlighter({theme: value}));
+          highlighterCache.set(mode, getHighlighter({theme: value}));
         }
       }
     }

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -294,6 +294,44 @@ code > .line::before {
 }
 ```
 
+### Custom highlighter
+
+To completely configure the highlighter, use the `getHighlighter` option to
+provide a Shiki highlighter instance.
+
+In order to support light and dark modes, Rehype Pretty Code provides an
+`options` object for you to extend. The `options.theme` attribute is
+preconfigured with the light or dark theme based on your theme options.
+
+This is helpful if you'd like to configure other Shiki options, such as `langs`.
+
+```js
+const {getHighlighter, BUNDLED_LANGUAGES} = require('shiki');
+
+const options = {
+  theme: {
+    dark: JSON.parse(
+      fs.readFileSync(require.resolve('./themes/dark.json'), 'utf-8')
+    ),
+    light: JSON.parse(
+      fs.readFileSync(require.resolve('./themes/light.json'), 'utf-8')
+    ),
+  },
+  getHighlighter: (options) =>
+    getHighlighter({
+      ...options,
+      langs: [
+        ...BUNDLED_LANGUAGES,
+        {
+          id: 'groq',
+          scopeName: 'source.groq',
+          path: './langs/vscode-sanity/grammars/groq.json',
+        },
+      ],
+    }),
+};
+```
+
 ## License
 
 MIT • [View on GitHub](https://github.com/atomiks/rehype-pretty-code)


### PR DESCRIPTION
At the moment, Rehype Pretty Code only allows the Shiki theme to be configured. By adding a `getHighlighter` option, we can let users configure any present or future Shiki options without having to manually add support for them in Rehype Pretty Code.

For example, it is currently impossible to configure the `langs` option. This change allows the user to pass in a highlighter instance with the `langs` option already set.

The `getHighlighter` function is given the theme options prepared by Rehype Pretty Code, allowing the custom highlighter to support light and dark modes.