### PR TITLE
fix: title - add theme, flatten children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,41 +13,39 @@ function toFragment({node, trees, lang, title, inline = false}) {
   node.tagName = inline ? 'span' : 'div';
   // User can replace this with a real Fragment at runtime
   node.properties = {'data-rehype-pretty-code-fragment': ''};
-  node.children = Object.entries(trees).map(([mode, tree]) => {
-    const pre = tree.children[0];
-    // Remove class="shiki" and the background-color
-    pre.properties = {};
+  node.children = Object.entries(trees)
+    .map(([mode, tree]) => {
+      const pre = tree.children[0];
+      // Remove class="shiki" and the background-color
+      pre.properties = {};
 
-    const code = pre.children[0];
-    code.properties['data-language'] = lang;
-    code.properties['data-theme'] = mode;
+      const code = pre.children[0];
+      code.properties['data-language'] = lang;
+      code.properties['data-theme'] = mode;
 
-    if (inline) {
-      return code;
-    }
+      if (inline) {
+        return code;
+      }
 
-    if (title) {
-      return {
-        type: 'element',
-        tagName: 'div',
-        properties: {'data-rehype-pretty-code-fragment': ''},
-        children: [
+      if (title) {
+        return [
           {
             type: 'element',
             tagName: 'div',
             properties: {
               'data-rehype-pretty-code-title': '',
               'data-language': lang,
+              'data-theme': mode,
             },
             children: [{type: 'text', value: title}],
           },
           pre,
-        ],
-      };
-    }
+        ];
+      }
 
-    return pre;
-  });
+      return pre;
+    })
+    .flatMap((c) => c);
 }
 
 export default function rehypePrettyCode(options = {}) {

--- a/test/results/title.html
+++ b/test/results/title.html
@@ -23,8 +23,8 @@
 <h2>Title</h2>
 <p>title="app.js"</p>
 <div data-rehype-pretty-code-fragment="">
-  <div data-rehype-pretty-code-fragment="">
-    <div data-rehype-pretty-code-title="" data-language="js">app.js</div>
-    <pre><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">code</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">true</span><span style="color: #C9D1D9">;</span></span></code></pre>
+  <div data-rehype-pretty-code-title="" data-language="js" data-theme="default">
+    app.js
   </div>
+  <pre><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">code</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">true</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>


### PR DESCRIPTION
- add the them to the **title** element- same deal as with `code`, it's needed to hide duplicate title when using multiple themes.
- return the title and pre as children without the extra fragment

![image](https://user-images.githubusercontent.com/13904763/152622890-602034a9-6c81-4b8a-83f0-6ca6b0812e0c.png)


fixes #18 