### PR TITLE
refactor: avoid Array.prototype.at() for old JS runtimes

### DIFF
--- a/src/wordHighlighter/wordHighlighter.js
+++ b/src/wordHighlighter/wordHighlighter.js
@@ -32,7 +32,7 @@ export function wordHighlighter(node, word, options, onVisitHighlightedWord) {
         wrapHighlightedWords(node, nodesToWrap, onVisitHighlightedWord);
         // re-start from the 'last' node (the word or part of it may exist multiple times in the same node)
         // account for possible extra nodes added from split with - 2
-        startIndex = Math.max(nodesToWrap.at(-1).index - 2, 0);
+        startIndex = Math.max(nodesToWrap[nodesToWrap.length - 1].index - 2, 0);
         textContent = node.children
           ?.map((childNode) => {
             if (


### PR DESCRIPTION
Closes #22 

@HamedBahram