### PR TITLE
Fix custom highlighter typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export type Options = {
   onVisitLine(node: any): void;
   onVisitHighlightedLine(node: any): void;
   onVisitHighlightedWord(node: any): void;
-  getHighlighter?: (options: Pick<Options, 'theme'>) => Highlighter;
+  getHighlighter?: (options: Pick<Options, 'theme'>) => Promise<Highlighter>;
 };
 
 declare const rehypePrettyCode: (options?: Partial<Options>) => any;


### PR DESCRIPTION
`getHighlighter` should return a promise, not the `Highlighter` directly. Proof:
1. https://github.com/atomiks/rehype-pretty-code/blob/0f23082c11a0ebe00c240cc42998d95c95002c27/src/index.js#L80-L82
2. https://github.com/shikijs/shiki/blob/27691ea35898fd7aec5df524108493c1bb4850aa/packages/shiki/src/highlighter.ts#L42