### PR TITLE
fix: avoid word match inside title

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,14 +138,18 @@ export default function rehypePrettyCode(options = {}) {
         );
         const meta =
           node.children[0].data?.meta ?? node.children[0].properties.metastring;
+        const titleMatch = meta?.match(/title="(.+)"/);
+        const title = titleMatch?.[1] ?? null;
+        const titleString = titleMatch?.[0] ?? '';
+        const metaWithoutTitle = meta?.replace(titleString, '');
+
         const lineNumbers = meta
-          ? rangeParser(meta.match(/{(.*)}/)?.[1] ?? '')
+          ? rangeParser(metaWithoutTitle.match(/{(.*)}/)?.[1] ?? '')
           : [];
-        const word = meta?.match(/\/(.*)\//)?.[1];
+        const word = metaWithoutTitle?.match(/\/(.*)\//)?.[1];
         const wordNumbers = meta
-          ? rangeParser(meta.match(/\/.*\/([^\s]*)/)?.[1] ?? '')
+          ? rangeParser(metaWithoutTitle.match(/\/.*\/([^\s]*)/)?.[1] ?? '')
           : [];
-        const title = meta?.match(/title="(.+)"/)?.[1] ?? null;
 
         const trees = {};
         for (const [mode, highlighter] of highlighters.entries()) {

--- a/test/fixtures/title.md
+++ b/test/fixtures/title.md
@@ -5,3 +5,15 @@ title="app.js"
 ```js title="app.js"
 const code = true;
 ```
+
+title="./components/index.js"
+
+```js title="./components/index.js"
+const title = 'components';
+```
+
+title="./components/{4}.js" /title/
+
+```js title="./components/{4}.js" /title/
+const title = 'components';
+```

--- a/test/results/title.html
+++ b/test/results/title.html
@@ -31,3 +31,23 @@
     data-theme="default"
   ><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">code</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">true</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>
+<p>title="./components/index.js"</p>
+<div data-rehype-pretty-code-fragment="">
+  <div data-rehype-pretty-code-title="" data-language="js" data-theme="default">
+    ./components/index.js
+  </div>
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">title</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'components'</span><span style="color: #C9D1D9">;</span></span></code></pre>
+</div>
+<p>title="./components/{4}.js" /title/</p>
+<div data-rehype-pretty-code-fragment="">
+  <div data-rehype-pretty-code-title="" data-language="js" data-theme="default">
+    ./components/{4}.js
+  </div>
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF" class="word">title</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'components'</span><span style="color: #C9D1D9">;</span></span></code></pre>
+</div>


### PR DESCRIPTION
I noticed if you have a path in your title, lik `title="/components/index.js"` that will be picked up by the word regex, and in this example `components` would be highlighted in the code.

I've just done the proceeding matches on the meta with the title removed, should be fine I think. 
Maybe there's a way to do a regex negative lookahead to omit `\/(.*)\/` when inside the quotes but I couldn't figure one out.

![image](https://user-images.githubusercontent.com/13904763/165022296-ab043410-58e1-4a8f-a7be-798387aef9cb.png)
