### PR TITLE
fix: cache highlighters per processor

### DIFF
--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -71,6 +71,16 @@ describe('with fixtures', () => {
   });
 });
 
+it("highlighter caches don't overwrite each other", async () => {
+  const [html1, html2] = await Promise.all([
+    getHTML('`[1, 2, 3]{:js}`', {theme: 'github-light'}),
+    getHTML('`[1, 2, 3]{:js}`', {theme: 'light-plus'}),
+  ]);
+  // both highlighters are being cached under the same key, but in separate caches,
+  // that's what we're testing here by asserting that they yield different results
+  expect(html1).not.toBe(html2);
+});
+
 const defaultStyle = `
 <style>
   html {


### PR DESCRIPTION
Since #27 highlighters were being created once per every tree, which resulted in significant performance regression (#36). Between caching once per Node process and not caching at all there is a third option: caching per unified processor, which is exactly what we want! We will still get all the benefits of caching without running into the problems of themes not updating and multiple processors using the same cache.

The two problems I wanted to avoid when I saw caching per Node process were the following:

1. **Multiple unified processors using the same cache.**

```js
import { unified } from 'unified'
import remarkParse form 'remark-parse'
import remarkRehype from 'remark-rehype'
import rehypePrettyCode from 'rehype-pretty-code'
import rehypeStringify from 'rehype-stringify'

function createMarkdownProcessor(theme) {
  return unified()
    .use(remarkParse)
    .use(remarkRehype)
    .use(rehypePrettyCode, { theme: 'monokai' })
    .use(rehypeStringify)
}

const monokaiProcessor = createMarkdownProcessor('monokai')
const githubDarkProcessor = createMarkdownProcessor('github-dark')

monokaiProcessor.processSync('`[1, 2, 3]{:js}`') // monokai
githubDarkProcessor.processSync('`[1, 2, 3]{:js}`') // monokai
```

The problem here are since both of these were using the same cache, so if the processor with `monokai` ran first, running the `github-dark` processor would use the `monokai` theme again.

2. **Changing themes within the same Node process wouldn't have effect.**

This is because the highlighters already got cached on Node process level, and since the process is still running the cache is there too.

This change caches the highlighters on the unified processor level, so you can create as many processors as you like, they will all get cached separately.

Fixes #36.