### PR TITLE
feat: add custom line number

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
-* text eol=lf
+
+/test/fixtures/**/* text eol=lf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehype-pretty-code",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rehype-pretty-code",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "workspaces": [
         "./website",
@@ -3047,9 +3047,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001320",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
-      "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -13946,9 +13946,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001320",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
-      "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA=="
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ=="
     },
     "ccount": {
       "version": "2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ export default function rehypePrettyCode(options = {}) {
               if (index === 0) {
                 const lineNumbersStartAtMatch = meta.match(/(?<!\/.*?)showLineNumbers(?:\{(\d+)})?/);
                 if (lineNumbersStartAtMatch[1])
-                  node.properties['style'] = `counter-set: line ${lineNumbersStartAtMatch[1]};`;
+                  node.properties['style'] = `counter-set: line ${lineNumbersStartAtMatch[1] - 1};`;
               }
             }
 

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,7 @@ export default function rehypePrettyCode(options = {}) {
           }
         }
 
-        Object.entries(trees).forEach(([mode, tree]) => {
+        Object.entries(trees).forEach(([mode, tree], index) => {
           let lineCounter = 0;
           const wordOptions = {wordNumbers, wordCounter: 0};
 
@@ -204,6 +204,12 @@ export default function rehypePrettyCode(options = {}) {
               /(?<!\/.*?)showLineNumbers/.test(meta)
             ) {
               node.properties['data-line-numbers'] = '';
+
+              if (index === 0) {
+                const lineNumbersStartAtMatch = meta.match(/(?<!\/.*?)showLineNumbers(?:\{(\d+)})?/);
+                if (lineNumbersStartAtMatch[1])
+                  node.properties['style'] = `counter-set: line ${lineNumbersStartAtMatch[1]};`;
+              }
             }
 
             if (node.properties.className?.[0] === 'line') {

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -102,5 +102,17 @@ const defaultStyle = `
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 `;

--- a/test/fixtures/showLineNumbersStartAt.md
+++ b/test/fixtures/showLineNumbersStartAt.md
@@ -1,0 +1,21 @@
+## showLineNumbersStartAt
+
+showLineNumbersStartAt
+
+```js showLineNumbers
+const a = 'a';
+const b = 'b';
+const c = 'c';
+```
+
+```js showLineNumbers{5}
+const a = 'a';
+const b = 'b';
+const c = 'c';
+```
+
+```js showLineNumbers{100}
+const a = 'a';
+const b = 'b';
+const c = 'c';
+```

--- a/test/results/highlightPartialNode.html
+++ b/test/results/highlightPartialNode.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted partial node</h2>
 <p>/carrot/</p>

--- a/test/results/highlightedLine.html
+++ b/test/results/highlightedLine.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted line</h2>
 <p>{1}</p>

--- a/test/results/highlightedLines.html
+++ b/test/results/highlightedLines.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted lines</h2>
 <p>{1, 3, 6-8}</p>

--- a/test/results/highlightedMultipleWord.html
+++ b/test/results/highlightedMultipleWord.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted multiple word</h2>
 <p>/carrot/ /return/</p>

--- a/test/results/highlightedMultipleWords.html
+++ b/test/results/highlightedMultipleWords.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted multiple words</h2>
 <p>/getStringLength/1-2 /str/1,3</p>

--- a/test/results/highlightedWord.html
+++ b/test/results/highlightedWord.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted word</h2>
 <p>/carrot/</p>

--- a/test/results/highlightedWords.html
+++ b/test/results/highlightedWords.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Highlighted words</h2>
 <p>/getStringLength/1-2</p>

--- a/test/results/highlightedWordsComplex.html
+++ b/test/results/highlightedWordsComplex.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <p>/&#x3C;span class="test/</p>
 <div data-rehype-pretty-code-fragment="">

--- a/test/results/inline.html
+++ b/test/results/inline.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Inline</h2>
 <p>{:js}</p>

--- a/test/results/manyLines.html
+++ b/test/results/manyLines.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Many line</h2>
 <div data-rehype-pretty-code-fragment="">

--- a/test/results/multiWordLanguage.html
+++ b/test/results/multiWordLanguage.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h1>Hyphenated language</h1>
 <div data-rehype-pretty-code-fragment="">

--- a/test/results/oneLine.html
+++ b/test/results/oneLine.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>One line</h2>
 <div data-rehype-pretty-code-fragment="">

--- a/test/results/showLineNumbers.html
+++ b/test/results/showLineNumbers.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>showLineNumbers</h2>
 <p>showLineNumbers</p>

--- a/test/results/showLineNumbersStartAt.html
+++ b/test/results/showLineNumbersStartAt.html
@@ -1,0 +1,60 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    background: black;
+    display: grid;
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  .highlighted, .word {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+</style>
+<h2>showLineNumbersStartAt</h2>
+<p>showLineNumbersStartAt</p>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-line-numbers="" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+<span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
+<span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
+</div>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-line-numbers="" style="counter-set: line 5;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+<span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
+<span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
+</div>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-line-numbers="" style="counter-set: line 100;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+<span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
+<span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
+</div>

--- a/test/results/showLineNumbersStartAt.html
+++ b/test/results/showLineNumbersStartAt.html
@@ -46,7 +46,7 @@
   <pre
     data-language="js"
     data-theme="default"
-  ><code data-line-numbers="" style="counter-set: line 5;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+  ><code data-line-numbers="" style="counter-set: line 4;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>
@@ -54,7 +54,7 @@
   <pre
     data-language="js"
     data-theme="default"
-  ><code data-line-numbers="" style="counter-set: line 100;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+  ><code data-line-numbers="" style="counter-set: line 99;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>

--- a/test/results/title.html
+++ b/test/results/title.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>Title</h2>
 <p>title="app.js"</p>

--- a/test/results/undefined.html
+++ b/test/results/undefined.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h2>undefined</h2>
 <p>Should not be highlighted</p>

--- a/test/results/unknownLanguage.html
+++ b/test/results/unknownLanguage.html
@@ -19,6 +19,18 @@
   .highlighted, .word {
     background-color: rgba(255, 255, 255, 0.25);
   }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
 </style>
 <h1>Unknown language</h1>
 <div data-rehype-pretty-code-fragment="">

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -283,6 +283,14 @@ If you want to conditionally show them, use `showLineNumbers`:
 ```
 ````
 
+If you want to start line number at specific number, use `showLineNumbers{number}`:
+
+````md
+```js showLineNumbers{number}
+// the first line of this code block will start at {number}
+```
+````
+
 ### Multiple themes (dark/light mode)
 
 Because Shiki generates themes at build time, client-side theme switching


### PR DESCRIPTION
fixes #44  

**New Syntax: showLineNumbers{\<number\>}**
````
```text showLineNumbers{20}
//some text
```
````
Line numbers of this code block will be start counting from 20

If no start line number provided, it will work the same as before
````
```text showLineNumbers
//some text
```
````