### PR TITLE
fix unexpected highlight words for custom meta properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ export default function rehypePrettyCode(options = {}) {
         }
 
         // TODO: allow escape characters to break out of highlighting
-        const stippedValue = value.replace(/{:[a-zA-Z.-]+}/, '');
+        const strippedValue = value.replace(/{:[a-zA-Z.-]+}/, '');
         const meta = value.match(/{:([a-zA-Z.-]+)}$/)?.[1];
 
         if (!meta) {
@@ -136,11 +136,11 @@ export default function rehypePrettyCode(options = {}) {
                 )?.settings.foreground ?? 'inherit';
 
             trees[mode] = hastParser.parse(
-              `<pre><code><span style="color:${color}">${stippedValue}</span></code></pre>`
+              `<pre><code><span style="color:${color}">${strippedValue}</span></code></pre>`
             );
           } else {
             trees[mode] = hastParser.parse(
-              highlighter.codeToHtml(stippedValue, meta)
+              highlighter.codeToHtml(strippedValue, meta)
             );
           }
         }
@@ -169,16 +169,15 @@ export default function rehypePrettyCode(options = {}) {
           node.children[0].data?.meta ?? node.children[0].properties.metastring;
         const titleMatch = meta?.match(/title="(.+)"/);
         const title = titleMatch?.[1] ?? null;
-        const titleString = titleMatch?.[0] ?? '';
-        const metaWithoutTitle = meta?.replace(titleString, '');
+        const cleanedMeta = meta?.replace(/\w+="[^"]*"/g, '');
 
         const lineNumbers = meta
-          ? rangeParser(metaWithoutTitle.match(/{(.*)}/)?.[1] ?? '')
+          ? rangeParser(cleanedMeta.match(/{(.*)}/)?.[1] ?? '')
           : [];
 
         let word = [];
-        const wordMatch = metaWithoutTitle
-          ? [...metaWithoutTitle.matchAll(/\/(.*?)\//g)]
+        const wordMatch = cleanedMeta
+          ? [...cleanedMeta.matchAll(/\/(.*?)\//g)]
           : undefined;
         if (Array.isArray(wordMatch)) {
           wordMatch.forEach((name, index) => {
@@ -188,8 +187,8 @@ export default function rehypePrettyCode(options = {}) {
 
         let wordNumbers = [];
         if (meta) {
-          const wordNumbersMatch = metaWithoutTitle
-            ? [...metaWithoutTitle.matchAll(/\/.*?\/(\S*)/g)]
+          const wordNumbersMatch = cleanedMeta
+            ? [...cleanedMeta.matchAll(/\/.*?\/(\S*)/g)]
             : undefined;
           if (Array.isArray(wordNumbersMatch)) {
             wordNumbersMatch.forEach((name, index) => {


### PR DESCRIPTION
use better regex 
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/7361780/209485140-23f96949-2f19-4e62-8b43-e8d4fe5f73fd.png">
fixes https://github.com/atomiks/rehype-pretty-code/issues/52