### PR TITLE
feat: `filterMetaString` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ type theme = JSON | string;
 export type Options = {
   theme: theme | Record<any, theme>;
   tokensMap: {[key: string]: string};
+  filterMetaString: (string: string) => string;
   // TODO: strict types
   onVisitLine(node: any): void;
   onVisitHighlightedLine(node: any): void;

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -31,6 +31,7 @@ const runFixture = async (fixture, fixtureName, getHighlighter) => {
   const code = readFileSync(fixture, 'utf8');
 
   const html = await getHTML(code, {
+    filterMetaString: (string) => string?.replace(/filename=".*"/, ''),
     theme: JSON.parse(
       readFileSync(
         join(__dirname, '../node_modules/shiki/themes/github-dark.json'),

--- a/test/fixtures/filterMetaString.md
+++ b/test/fixtures/filterMetaString.md
@@ -1,0 +1,5 @@
+# Filter meta string
+
+```js filename="/node/"
+const node = '';
+```

--- a/test/results/filterMetaString.html
+++ b/test/results/filterMetaString.html
@@ -1,0 +1,41 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    background: black;
+    display: grid;
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  .highlighted, .word {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+</style>
+<h1>Filter meta string</h1>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">node</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">''</span><span style="color: #C9D1D9">;</span></span></code></pre>
+</div>


### PR DESCRIPTION
If the meta string also has custom config by you, it may cause issues with word highlighting or other features of `rehype-pretty-code`.

So Nextra would specify:

```js
const options = {
  filterMetaString: (string) => string.replace(/filename=".*"/, ''),
};
```

@B2o5T