### PR TITLE
fix: move `lineNumbersMaxDigits` from CSS variable to data attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,14 +38,8 @@ function toFragment({
       }
 
       if ('data-line-numbers' in code.properties) {
-        const cssVariable = `--line-numbers-max-digits: ${
-          lineNumbersMaxDigits.toString().length
-        };`;
-        if ('style' in code.properties) {
-          code.properties.style += cssVariable;
-        } else {
-          code.properties.style = cssVariable;
-        }
+        code.properties['data-line-numbers-max-digits'] =
+          lineNumbersMaxDigits.toString().length;
       }
 
       if (title) {

--- a/test/results/showLineNumbers.html
+++ b/test/results/showLineNumbers.html
@@ -38,7 +38,7 @@
   <pre
     data-language="js"
     data-theme="default"
-  ><code data-line-numbers="" data-language="js" data-theme="default" style="--line-numbers-max-digits: 1;"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+  ><code data-line-numbers="" data-language="js" data-theme="default" data-line-numbers-max-digits="1"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>

--- a/test/results/showLineNumbersStartAt.html
+++ b/test/results/showLineNumbersStartAt.html
@@ -38,7 +38,7 @@
   <pre
     data-language="js"
     data-theme="default"
-  ><code data-line-numbers="" data-language="js" data-theme="default" style="--line-numbers-max-digits: 1;"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+  ><code data-line-numbers="" data-language="js" data-theme="default" data-line-numbers-max-digits="1"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>
@@ -46,7 +46,7 @@
   <pre
     data-language="js"
     data-theme="default"
-  ><code data-line-numbers="" style="counter-set: line 4;--line-numbers-max-digits: 1;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+  ><code data-line-numbers="" style="counter-set: line 4;" data-language="js" data-theme="default" data-line-numbers-max-digits="1"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>
@@ -54,7 +54,7 @@
   <pre
     data-language="js"
     data-theme="default"
-  ><code data-line-numbers="" style="counter-set: line 99;--line-numbers-max-digits: 3;" data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
+  ><code data-line-numbers="" style="counter-set: line 99;" data-language="js" data-theme="default" data-line-numbers-max-digits="3"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">a</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'a'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">b</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'b'</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">c</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">'c'</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -326,10 +326,18 @@ code > .line::before {
 
   /* Other styling */
   display: inline-block;
-  width: calc(var(--line-numbers-max-digits) * 1rem);
+  width: 1rem;
   margin-right: 2rem;
   text-align: right;
   color: gray;
+}
+
+code[data-line-numbers-max-digits="2"] > .line::before {
+  width: 2rem;
+}
+
+code[data-line-numbers-max-digits="3"] > .line::before {
+  width: 3rem;
 }
 ```
 
@@ -337,8 +345,8 @@ If you want to conditionally show them, use `showLineNumbers`:
 
 ````md
 ```js showLineNumbers
-// <code> will have a `data-line-numbers` attribute and
-// CSS variable `--line-numbers-max-digits`
+// <code> will have attributes `data-line-numbers` and
+// `data-line-numbers-max-digits="n"`
 ```
 ````
 


### PR DESCRIPTION
CSS variable seems problematic to `@next/mdx` and `@astrojs/mdx` (at least what I'm tested), move to data attribute.

```css
code > .line::before {
  width: 1rem;
}

code[data-line-numbers-max-digits="2"] > .line::before {
  width: 2rem;
}

code[data-line-numbers-max-digits="3"] > .line::before {
  width: 3rem;
}

// ...
```