### PR TITLE
feat: support keepBackground option in inline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ function toFragment({
       code.properties['data-theme'] = mode;
 
       if (inline) {
+        if (keepBackground) code.properties['style'] = pre.properties['style'];
         return code;
       }
 
@@ -162,7 +163,7 @@ export default function rehypePrettyCode(options = {}) {
           }
         }
 
-        toFragment({node, trees, lang: isLang ? meta : '.token', inline: true});
+        toFragment({node, trees, lang: isLang ? meta : '.token', inline: true, keepBackground});
       }
 
       if (

--- a/test/fixtures/keepBackground.md
+++ b/test/fixtures/keepBackground.md
@@ -1,3 +1,5 @@
 ```js
 const x = true;
 ```
+
+`const x = true;{:js}`

--- a/test/results/keepBackground.html
+++ b/test/results/keepBackground.html
@@ -41,7 +41,10 @@
 </div>
 <p>
   <span data-rehype-pretty-code-fragment=""
-    ><code data-language="js" data-theme="default"
+    ><code
+      data-language="js"
+      data-theme="default"
+      style="background-color: #0d1117"
       ><span class="line"
         ><span style="color: #ff7b72">const</span
         ><span style="color: #c9d1d9"> </span

--- a/test/results/keepBackground.html
+++ b/test/results/keepBackground.html
@@ -39,3 +39,19 @@
     data-theme="default"
   ><code data-language="js" data-theme="default"><span class="line"><span style="color: #FF7B72">const</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">x</span><span style="color: #C9D1D9"> </span><span style="color: #FF7B72">=</span><span style="color: #C9D1D9"> </span><span style="color: #79C0FF">true</span><span style="color: #C9D1D9">;</span></span></code></pre>
 </div>
+<p>
+  <span data-rehype-pretty-code-fragment=""
+    ><code data-language="js" data-theme="default"
+      ><span class="line"
+        ><span style="color: #ff7b72">const</span
+        ><span style="color: #c9d1d9"> </span
+        ><span style="color: #79c0ff">x</span
+        ><span style="color: #c9d1d9"> </span
+        ><span style="color: #ff7b72">=</span
+        ><span style="color: #c9d1d9"> </span
+        ><span style="color: #79c0ff">true</span
+        ><span style="color: #c9d1d9">;</span></span
+      ></code
+    ></span
+  >
+</p>


### PR DESCRIPTION
Hi!
This PR  uses the theme background color as the inline background when the keepBackground option is true. In the current version, the inline background color does not change.