### PR TITLE
fix: change `lineNumbers` regex to respect positioning/existence of `showLineNumbers{x}`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ export default function rehypePrettyCode(options = {}) {
         meta = meta.replace(tiltleMatch?.[0] ?? '', '');
 
         const lineNumbers = meta
-          ? rangeParser(meta.match(/{(.*)}/)?.[1] ?? '')
+          ? rangeParser(meta.match(/(?<!\S){(.*?)}/)?.[1] ?? '')
           : [];
         let lineNumbersMaxDigits = 0;
 

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ export default function rehypePrettyCode(options = {}) {
         meta = meta.replace(tiltleMatch?.[0] ?? '', '');
 
         const lineNumbers = meta
-          ? rangeParser(meta.match(/(?<!\S){(.*?)}/)?.[1] ?? '')
+          ? rangeParser(meta.match(/(?:^|\s){(.*?)}/)?.[1] ?? '')
           : [];
         let lineNumbersMaxDigits = 0;
 

--- a/test/fixtures/highlightedLinesWithShowLineNumbersAt.md
+++ b/test/fixtures/highlightedLinesWithShowLineNumbersAt.md
@@ -1,0 +1,29 @@
+## Highlighted lines with showLineNumbersAt
+
+{1, 3, 6-8} showLineNumbers{3}
+
+```js {1, 3, 6-8} showLineNumbers{3}
+const getStringLength = (str) => str.length;
+
+const add = (a, b) => a + b;
+
+const divide = (a, b) => a / b;
+
+const subtract = (a, b) => a - b;
+
+const multiply = (a, b) => a * b;
+```
+
+showLineNumbers{3} {1, 3, 6-8}
+
+```js showLineNumbers{3} {1, 3, 6-8}
+const getStringLength = (str) => str.length;
+
+const add = (x, y) => x + y;
+
+const divide = (x, y) => x / y;
+
+const subtract = (x, y) => x - y;
+
+const multiply = (x, y) => x * y;
+```

--- a/test/results/highlightedLinesWithShowLineNumbersAt.html
+++ b/test/results/highlightedLinesWithShowLineNumbersAt.html
@@ -1,0 +1,65 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    background: black;
+    display: grid;
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  .highlighted, .word {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+</style>
+<h2>Highlighted lines with showLineNumbersAt</h2>
+<p>{1, 3, 6-8} showLineNumbers{3}</p>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-line-numbers="" style="counter-set: line 2;" data-language="js" data-theme="default" data-line-numbers-max-digits="2"><span class="highlighted"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">getStringLength</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">str</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> str.</span><span style="color: #79B8FF">length</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="highlighted"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">add</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">+</span><span style="color: #E1E4E8"> b;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">divide</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">/</span><span style="color: #E1E4E8"> b;</span></span>
+<span class="highlighted"></span>
+<span class="highlighted"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">subtract</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">-</span><span style="color: #E1E4E8"> b;</span></span>
+<span class="highlighted"></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">multiply</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">*</span><span style="color: #E1E4E8"> b;</span></span></code></pre>
+</div>
+<p>showLineNumbers{3} {1, 3, 6-8}</p>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="default"
+  ><code data-line-numbers="" style="counter-set: line 2;" data-language="js" data-theme="default" data-line-numbers-max-digits="2"><span class="highlighted"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">getStringLength</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">str</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> str.</span><span style="color: #79B8FF">length</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="highlighted"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">add</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">x</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">y</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> x </span><span style="color: #F97583">+</span><span style="color: #E1E4E8"> y;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">divide</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">x</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">y</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> x </span><span style="color: #F97583">/</span><span style="color: #E1E4E8"> y;</span></span>
+<span class="highlighted"></span>
+<span class="highlighted"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">subtract</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">x</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">y</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> x </span><span style="color: #F97583">-</span><span style="color: #E1E4E8"> y;</span></span>
+<span class="highlighted"></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">multiply</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">x</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">y</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> x </span><span style="color: #F97583">*</span><span style="color: #E1E4E8"> y;</span></span></code></pre>
+</div>


### PR DESCRIPTION
When `showLineNumbers` exists with a value to start at, like `showLineNumbers{3}`, the line highlighter potentially grabs that number instead of the appropriate line highlight group, causing line highlights to not function correctly.

The new regex essentially checks to see if there are any characters before the `{` other than white space and filters them out. If there is a white space before the `{`, it's the correct group for line highlights.

If you run the additional test, but without the changes in `src/index.js`, the test fails. It then passes with the changes.