### PR TITLE
fix: showLineNumbers{n} with Multiple theme bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,15 +262,13 @@ export default function rehypePrettyCode(options = {}) {
             ) {
               node.properties['data-line-numbers'] = '';
 
-              if (index === 0) {
-                const lineNumbersStartAtMatch = reverseString(meta).match(
-                  /(?:\}(\d+){)?srebmuNeniLwohs(?!(.*)(\/))/
-                );
-                if (lineNumbersStartAtMatch[1]) {
-                  const startAt = reverseString(lineNumbersStartAtMatch[1]) - 1;
-                  lineNumbersMaxDigits = startAt;
-                  node.properties['style'] = `counter-set: line ${startAt};`;
-                }
+              const lineNumbersStartAtMatch = reverseString(meta).match(
+                /(?:\}(\d+){)?srebmuNeniLwohs(?!(.*)(\/))/
+              );
+              if (lineNumbersStartAtMatch[1]) {
+                const startAt = reverseString(lineNumbersStartAtMatch[1]) - 1;
+                lineNumbersMaxDigits = startAt;
+                node.properties['style'] = `counter-set: line ${startAt};`;
               }
             }
 

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -50,7 +50,8 @@ const getTheme = (multiple) => {
 
 // To add a test, create a markdown file in the fixtures folder
 const runFixture = async (fixture, fixtureName, getHighlighter) => {
-  const resultHTMLName = parse(fixtureName).name + '.html';
+  const testName = parse(fixtureName).name;
+  const resultHTMLName = testName + '.html';
   const resultHTMLPath = join(resultsFolder, resultHTMLName);
   const isMultipleThemeTest = resultHTMLName.toLowerCase().includes('multipletheme');
   const code = readFileSync(fixture, 'utf8');

--- a/test/fixtures/showLineNumbersStartAtMultipleTheme.md
+++ b/test/fixtures/showLineNumbersStartAtMultipleTheme.md
@@ -1,0 +1,21 @@
+## showLineNumbersStartAt
+
+showLineNumbersStartAt
+
+```js showLineNumbers
+const a = 'a';
+const b = 'b';
+const c = 'c';
+```
+
+```js showLineNumbers{5}
+const a = 'a';
+const b = 'b';
+const c = 'c';
+```
+
+```js showLineNumbers{100}
+const a = 'a';
+const b = 'b';
+const c = 'c';
+```

--- a/test/results/showLineNumbersStartAtMultipleTheme.html
+++ b/test/results/showLineNumbersStartAtMultipleTheme.html
@@ -1,0 +1,78 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    background: black;
+    display: grid;
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  .highlighted, .word {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>.line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+</style>
+<h2>showLineNumbersStartAt</h2>
+<p>showLineNumbersStartAt</p>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="dark"
+  ><code data-line-numbers="" data-language="js" data-theme="dark" data-line-numbers-max-digits="1"><span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">a</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'a'</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">b</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'b'</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">c</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'c'</span><span style="color: #E1E4E8">;</span></span></code></pre>
+  <pre
+    data-language="js"
+    data-theme="light"
+  ><code data-line-numbers="" data-language="js" data-theme="light" data-line-numbers-max-digits="1"><span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'a'</span><span style="color: #24292E">;</span></span>
+<span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">b</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'b'</span><span style="color: #24292E">;</span></span>
+<span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">c</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'c'</span><span style="color: #24292E">;</span></span></code></pre>
+</div>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="dark"
+  ><code data-line-numbers="" style="counter-set: line 4;" data-language="js" data-theme="dark" data-line-numbers-max-digits="1"><span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">a</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'a'</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">b</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'b'</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">c</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'c'</span><span style="color: #E1E4E8">;</span></span></code></pre>
+  <pre
+    data-language="js"
+    data-theme="light"
+  ><code data-line-numbers="" style="counter-set: line 4;" data-language="js" data-theme="light" data-line-numbers-max-digits="1"><span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'a'</span><span style="color: #24292E">;</span></span>
+<span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">b</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'b'</span><span style="color: #24292E">;</span></span>
+<span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">c</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'c'</span><span style="color: #24292E">;</span></span></code></pre>
+</div>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    data-language="js"
+    data-theme="dark"
+  ><code data-line-numbers="" style="counter-set: line 99;" data-language="js" data-theme="dark" data-line-numbers-max-digits="3"><span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">a</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'a'</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">b</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'b'</span><span style="color: #E1E4E8">;</span></span>
+<span class="line"><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">c</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'c'</span><span style="color: #E1E4E8">;</span></span></code></pre>
+  <pre
+    data-language="js"
+    data-theme="light"
+  ><code data-line-numbers="" style="counter-set: line 99;" data-language="js" data-theme="light" data-line-numbers-max-digits="3"><span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'a'</span><span style="color: #24292E">;</span></span>
+<span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">b</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'b'</span><span style="color: #24292E">;</span></span>
+<span class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">c</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #032F62">'c'</span><span style="color: #24292E">;</span></span></code></pre>
+</div>


### PR DESCRIPTION
## Related Issue
There is an issue with the functionality of specifying the starting line number when using `showLineNumbers{n}` with Multiple Themes. [#80](link-to-issue)

## Root Cause Analysis
In the case of applying multiple themes, the `index` of the code element node with the second theme is 1. Therefore, it fails to pass the condition `if (index === 0)`, resulting in the failure of the logic that sets the counter-set as an inline style.

## Problem Resolution
The condition `if (index === 0)` has been removed. It has been verified that the tests are passing.
![image](https://github.com/atomiks/rehype-pretty-code/assets/35288028/288f8680-b00a-4641-a364-c4a3189d38db)

## Request for Feedback
Are there any potential issues or concerns with removing the condition `if (index === 0)`?