### PR TITLE
feat: add default language support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ type Theme = JSON | string;
 export interface Options {
   theme: Theme | Record<string, Theme>;
   keepBackground: boolean;
+  defaultCodeBlockLang: string;
+  defaultInlineCodeLang: string;
   tokensMap: Record<string, string>;
   filterMetaString: (str: string) => string;
   onVisitLine(node: Node): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,7 @@ type Theme = JSON | string;
 export interface Options {
   theme: Theme | Record<string, Theme>;
   keepBackground: boolean;
-  defaultCodeBlockLang: string;
-  defaultInlineCodeLang: string;
+  defaultLang: string | { block?: string; inline?: string },
   tokensMap: Record<string, string>;
   filterMetaString: (str: string) => string;
   onVisitLine(node: Node): void;

--- a/src/index.js
+++ b/src/index.js
@@ -88,8 +88,7 @@ export default function rehypePrettyCode(options = {}) {
   const {
     theme,
     keepBackground,
-    defaultCodeBlockLang,
-    defaultInlineCodeLang,
+    defaultLang,
     tokensMap = {},
     filterMetaString = (v) => v,
     onVisitLine = () => {},
@@ -116,6 +115,9 @@ export default function rehypePrettyCode(options = {}) {
   }
   const highlighters = new Map();
   const hastParser = unified().use(rehypeParse, {fragment: true});
+
+  const defaultCodeBlockLang = typeof defaultLang === 'string' ? defaultLang : defaultLang?.block;
+  const defaultInlineCodeLang = typeof defaultLang === 'string' ? defaultLang : defaultLang?.inline;
 
   if (
     theme == null ||

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,8 @@ export default function rehypePrettyCode(options = {}) {
   const {
     theme,
     keepBackground,
+    defaultCodeBlockLang,
+    defaultInlineCodeLang,
     tokensMap = {},
     filterMetaString = (v) => v,
     onVisitLine = () => {},
@@ -153,7 +155,7 @@ export default function rehypePrettyCode(options = {}) {
 
         // TODO: allow escape characters to break out of highlighting
         const strippedValue = value.replace(/{:[a-zA-Z.-]+}/, '');
-        const meta = value.match(/{:([a-zA-Z.-]+)}$/)?.[1];
+        const meta = value.match(/{:([a-zA-Z.-]+)}$/)?.[1] || defaultInlineCodeLang;
 
         if (!meta) {
           return;
@@ -202,15 +204,22 @@ export default function rehypePrettyCode(options = {}) {
         node.children.length === 1 &&
         node.children[0].tagName === 'code' &&
         typeof node.children[0].properties === 'object' &&
-        Array.isArray(node.children[0].properties.className) &&
-        typeof node.children[0].properties.className[0] === 'string' &&
-        node.children[0].properties.className[0].startsWith('language-')
+        typeof node.children[0].children[0] === 'object' &&
+        typeof node.children[0].children[0].value === 'string'
       ) {
         const codeNode = node.children[0].children[0];
-        const lang = node.children[0].properties.className[0].replace(
-          'language-',
-          ''
-        );
+
+        let lang = defaultCodeBlockLang;
+        if (
+            Array.isArray(node.children[0].properties.className) &&
+            typeof node.children[0].properties.className[0] === 'string'
+        ) {
+          lang = node.children[0].properties.className[0].replace(
+            'language-',
+            ''
+          ) || defaultCodeBlockLang;
+        }
+
         let meta = filterMetaString(
           node.children[0].data?.meta ??
             node.children[0].properties.metastring ??

--- a/website/src/app/index.mdx
+++ b/website/src/app/index.mdx
@@ -154,6 +154,11 @@ const options = {
   // Keep the background or use a custom background color?
   keepBackground: true,
 
+  // When not specify language at code block, use this as default language for highlighting
+  defaultCodeBlockLang: 'plaintext',
+  // When not specify language at inline code, use this as default language for highlighting
+  defaultInlineCodeLang: 'plaintext',
+
   // Callback hooks to add custom logic to nodes when visiting
   // them.
   onVisitLine(node) {

--- a/website/src/app/index.mdx
+++ b/website/src/app/index.mdx
@@ -154,10 +154,10 @@ const options = {
   // Keep the background or use a custom background color?
   keepBackground: true,
 
-  // When not specify language at code block, use this as default language for highlighting
-  defaultCodeBlockLang: 'plaintext',
-  // When not specify language at inline code, use this as default language for highlighting
-  defaultInlineCodeLang: 'plaintext',
+  // When not specify language at code block or inline code, use this as default language for highlighting
+  defaultLang: 'plaintext',
+  // Or specify default language for code blocks or inline code separately
+  defaultLang: { block: 'plaintext'; inline: 'plaintext' },
 
   // Callback hooks to add custom logic to nodes when visiting
   // them.


### PR DESCRIPTION
This commit adds an option to specify a default language.

Currently, if no language is specified when writing code block or inline code, the plugin will simply skip highlighting.

In the above case, if user specifies a default language, the plugin will use default language for highlighting; if user does not specify a default language, the plugin behavior will be consistent with the current one.