### PR TITLE
fix: remove unnecessary scrollbars on website when using firefox

### DIFF
--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -45,8 +45,8 @@ module.exports = {
             },
             code: {
               color: '#86e1fc',
-              '&::before': { content: `"" !important` },
-              '&::after': { content: `"" !important` },
+              '&::before': { content: `unset !important` },
+              '&::after': { content: `unset !important` },
               fontWeight: 'normal',
             },
             '[data-rehype-pretty-code-fragment]:nth-of-type(2) pre': {


### PR DESCRIPTION
This trick is used so that tailwind typography plugin doesn't add backticks around inline code, however it was adding a tiny bit of vertical scroll to code blocks unnecesarily when using firefox. Instead of setting `content: "" !important` we can use `content: unset !important` instead.

Before:
![Screenshot 2023-10-01 at 20 18 06](https://github.com/atomiks/rehype-pretty-code/assets/9155723/1d676a31-51d1-45ce-a69e-a1552b1b12e8)

After:
![Screenshot 2023-10-01 at 20 18 16](https://github.com/atomiks/rehype-pretty-code/assets/9155723/6323f436-a7d0-475a-959e-c5de31fcfc34)
