### PR TITLE
fix: line class omission

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,10 @@ function toFragment(
       const code = pre.children[0];
 
       // Remove class="shiki"
-      pre.properties.className = undefined;
+      if (Array.isArray(pre.properties?.className) && pre.properties?.className.includes('shiki')) {
+        const className = pre.properties.className.filter(c => c !== 'shiki');
+        pre.properties.className = className.length > 0 ? className : undefined;
+      }
 
       if (!keepBackground) {
         pre.properties = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -396,7 +396,8 @@ export default function rehypePrettyCode(
                 element.children = [{ type: 'text', value: ' ' }];
               }
 
-              element.properties.className = undefined;
+              const className = element.properties.className.filter(c => c !== 'line');
+              element.properties.className = className.length > 0 ? className : undefined;
               element.properties['data-line'] = '';
               onVisitLine?.(element as LineElement);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ function toFragment(
       }
 
       if (!keepBackground) {
-        pre.properties = {};
+        pre.properties.style = undefined;
       }
 
       pre.properties['data-language'] = lang;

--- a/test/results/ansi.html
+++ b/test/results/ansi.html
@@ -41,6 +41,7 @@
     vite --port 3123
   </div>
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="ansi"

--- a/test/results/caption.html
+++ b/test/results/caption.html
@@ -34,6 +34,7 @@
 <p>caption="Immutable variable declaration"</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -59,6 +60,7 @@
     ./components/index.js
   </div>
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -76,6 +78,7 @@
 <p>caption="Immutable variable declaration" /caption/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/defaultLang.block=js.html
+++ b/test/results/defaultLang.block=js.html
@@ -34,6 +34,7 @@
 <p>{ block: 'js' }</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/defaultLang.inline=js&block=js.html
+++ b/test/results/defaultLang.inline=js&block=js.html
@@ -34,6 +34,7 @@
 <p>{ block: 'js', inline: 'js' }</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/defaultLang.inline=js.html
+++ b/test/results/defaultLang.inline=js.html
@@ -34,6 +34,7 @@
 <p>{ inline: 'js' }</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language=""

--- a/test/results/defaultLang.js.html
+++ b/test/results/defaultLang.js.html
@@ -34,6 +34,7 @@
 <p>js</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/diff.html
+++ b/test/results/diff.html
@@ -33,6 +33,7 @@
 <h2>Diff</h2>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="diff"

--- a/test/results/filterMetaString.html
+++ b/test/results/filterMetaString.html
@@ -33,6 +33,7 @@
 <h1>Filter meta string</h1>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightChars.html
+++ b/test/results/highlightChars.html
@@ -34,6 +34,7 @@
 <p>/carrot/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightCharsById.html
+++ b/test/results/highlightCharsById.html
@@ -34,6 +34,7 @@
 <p>/age/#a /name/#a /setAge/#b /setName/#b /42/#c /'Taylor'/#c</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -62,6 +63,7 @@
 <p><code>/&#x3C;div/#a /id="true">/#b</code></p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -77,6 +79,7 @@
 <p>/age/#id</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -92,6 +95,7 @@
 <p>/age/2</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -101,6 +105,7 @@
 <p>/car/1</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightCharsComplex.html
+++ b/test/results/highlightCharsComplex.html
@@ -34,6 +34,7 @@
 <p>/&#x3C;span class="test/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -43,6 +44,7 @@
 <p>/span class="test"/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -52,6 +54,7 @@
 <p>/test"/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -61,6 +64,7 @@
 <p>/"test/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -70,6 +74,7 @@
 <p>/"te/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -79,6 +84,7 @@
 <p>/st"/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -88,6 +94,7 @@
 <p>/st">/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -97,6 +104,7 @@
 <p>/="te/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -106,6 +114,7 @@
 <p>/>/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -115,6 +124,7 @@
 <p>/&#x3C;/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -124,6 +134,7 @@
 <p>/&#x3C;>/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="html"
@@ -133,6 +144,7 @@
 <p>/theme: 'monokai'/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -144,6 +156,7 @@
 <p>/ theme: /</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -155,6 +168,7 @@
 <p>/light &#x26;&#x26; fluffy/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -166,6 +180,7 @@
 <p>/car/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -176,6 +191,7 @@
 <p>/car,/2</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -186,6 +202,7 @@
 <p>/,car/1</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -196,6 +213,7 @@
 <p>/ot,ca/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightCharsRange.html
+++ b/test/results/highlightCharsRange.html
@@ -34,6 +34,7 @@
 <p>/getStringLength/1-2</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -47,6 +48,7 @@
 <p>/getStringLength/1,3</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -60,6 +62,7 @@
 <p>/getStringLength/2,5,6</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightMultipleChars.html
+++ b/test/results/highlightMultipleChars.html
@@ -34,6 +34,7 @@
 <p>/carrot/ /return/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightPartialNode.html
+++ b/test/results/highlightPartialNode.html
@@ -34,6 +34,7 @@
 <p>/carrot/</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -44,6 +45,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -54,6 +56,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -64,6 +67,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightedLine.html
+++ b/test/results/highlightedLine.html
@@ -34,6 +34,7 @@
 <p>{1}</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightedLines.html
+++ b/test/results/highlightedLines.html
@@ -34,6 +34,7 @@
 <p>{1, 3, 6-8}</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightedLinesWithShowLineNumbersAt.html
+++ b/test/results/highlightedLinesWithShowLineNumbersAt.html
@@ -34,6 +34,7 @@
 <p>{1, 3, 6-8} showLineNumbers{3}</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -51,6 +52,7 @@
 <p>showLineNumbers{3} {1, 3, 6-8}</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/highlightedMultipleCharsRange.html
+++ b/test/results/highlightedMultipleCharsRange.html
@@ -34,6 +34,7 @@
 <p>/getStringLength/1-2 /str/1,3</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/keepBackground.html
+++ b/test/results/keepBackground.html
@@ -32,6 +32,8 @@
 </style>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
+    tabindex="0"
     data-language="js"
     data-theme="default"
   ><code data-language="js" data-theme="default" style="display: grid;"><span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">x</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">true</span><span style="color: #E1E4E8">;</span></span></code></pre>

--- a/test/results/manyLines.html
+++ b/test/results/manyLines.html
@@ -33,6 +33,7 @@
 <h2>Many line</h2>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="css"

--- a/test/results/multiWordLanguage.html
+++ b/test/results/multiWordLanguage.html
@@ -33,6 +33,7 @@
 <h1>Hyphenated language</h1>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="git-rebase"

--- a/test/results/oneLine.html
+++ b/test/results/oneLine.html
@@ -33,6 +33,7 @@
 <h2>One line</h2>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/showLineNumbers.html
+++ b/test/results/showLineNumbers.html
@@ -34,6 +34,7 @@
 <p>showLineNumbers</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -45,6 +46,7 @@
 <p>Literal is not highlighted 1</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -54,6 +56,7 @@
 <p>Literal is not highlighted 2</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/showLineNumbersStartAt.html
+++ b/test/results/showLineNumbersStartAt.html
@@ -34,6 +34,7 @@
 <p>showLineNumbersStartAt</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -44,6 +45,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -54,6 +56,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/showLineNumbersStartAtMultipleTheme.html
+++ b/test/results/showLineNumbersStartAtMultipleTheme.html
@@ -34,6 +34,7 @@
 <p>showLineNumbersStartAt</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -42,6 +43,7 @@
 <span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">b</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'b'</span><span style="color: #E1E4E8">;</span></span>
 <span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">c</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'c'</span><span style="color: #E1E4E8">;</span></span></code></pre>
   <pre
+    class="github-light"
     style="background-color: #fff"
     tabindex="0"
     data-language="js"
@@ -52,6 +54,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -60,6 +63,7 @@
 <span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">b</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'b'</span><span style="color: #E1E4E8">;</span></span>
 <span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">c</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'c'</span><span style="color: #E1E4E8">;</span></span></code></pre>
   <pre
+    class="github-light"
     style="background-color: #fff"
     tabindex="0"
     data-language="js"
@@ -70,6 +74,7 @@
 </div>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -78,6 +83,7 @@
 <span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">b</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'b'</span><span style="color: #E1E4E8">;</span></span>
 <span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">c</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">'c'</span><span style="color: #E1E4E8">;</span></span></code></pre>
   <pre
+    class="github-light"
     style="background-color: #fff"
     tabindex="0"
     data-language="js"

--- a/test/results/title.html
+++ b/test/results/title.html
@@ -42,6 +42,7 @@
     app.js
   </div>
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -59,6 +60,7 @@
     ./components/index.js
   </div>
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"
@@ -76,6 +78,7 @@
     ./components/{4}.js
   </div>
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/undefined.html
+++ b/test/results/undefined.html
@@ -34,6 +34,7 @@
 <p>Should not be highlighted</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="js"

--- a/test/results/unknownLanguage.html
+++ b/test/results/unknownLanguage.html
@@ -33,6 +33,7 @@
 <h1>Unknown language</h1>
 <div data-rehype-pretty-code-fragment="">
   <pre
+    class="github-dark"
     style="background-color: #24292e"
     tabindex="0"
     data-language="console"


### PR DESCRIPTION
Omitting the `className` completely means that the class names that the shiki processors inject as `createDiffProcessor`, `createHighlightProcessor`, etc, also get omitted.

Just making a change here to only omit the class we want (aka `"line"`).

This seemed to break between versions 0.9 and 0.10.