### PR TITLE
Adds Diff Highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehype-pretty-code",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rehype-pretty-code",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "hash-obj": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,13 @@ export default function rehypePrettyCode(
           : [];
         let lineNumbersMaxDigits = 0;
 
+        const addHighlights = meta
+          ? rangeParser(meta.match(/(?:^|\s)\+{(.*?)}/)?.[1] ?? '')
+          : [];
+        const removeHighlights = meta
+          ? rangeParser(meta.match(/(?:^|\s)-{(.*?)}/)?.[1] ?? '')
+          : [];
+
         const words: string[] = [];
         const wordNumbers: Array<number[]> = [];
         const wordIdsMap = new Map();
@@ -410,6 +417,20 @@ export default function rehypePrettyCode(
               ) {
                 element.properties['data-highlighted-line'] = '';
                 onVisitHighlightedLine?.(element as LineElement);
+              }
+
+              if (
+                addHighlights.length !== 0 &&
+                addHighlights.includes(++lineCounter)
+              ) {
+                element.properties['data-added-line'] = '';
+              }
+
+              if (
+                removeHighlights.length !== 0 &&
+                removeHighlights.includes(++lineCounter)
+              ) {
+                element.properties['data-removed-line'] = '';
               }
 
               charsHighlighter(

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ export default function rehypePrettyCode(
         }
 
         Object.entries(trees).forEach(([, tree]) => {
-          let lineCounter = 0;
+          let lineCounter = 1;
 
           const wordOptions: CharsHighlighterOptions = {
             ranges: wordNumbers,
@@ -413,7 +413,7 @@ export default function rehypePrettyCode(
 
               if (
                 lineNumbers.length !== 0 &&
-                lineNumbers.includes(++lineCounter)
+                lineNumbers.includes(lineCounter)
               ) {
                 element.properties['data-highlighted-line'] = '';
                 onVisitHighlightedLine?.(element as LineElement);
@@ -421,18 +421,19 @@ export default function rehypePrettyCode(
 
               if (
                 addHighlights.length !== 0 &&
-                addHighlights.includes(++lineCounter)
+                addHighlights.includes(lineCounter)
               ) {
                 element.properties['data-added-line'] = '';
               }
 
               if (
                 removeHighlights.length !== 0 &&
-                removeHighlights.includes(++lineCounter)
+                removeHighlights.includes(lineCounter)
               ) {
                 element.properties['data-removed-line'] = '';
               }
 
+              lineCounter += 1;
               charsHighlighter(
                 element,
                 words,

--- a/test/fixtures/addedLines.md
+++ b/test/fixtures/addedLines.md
@@ -1,6 +1,6 @@
 ## Added lines
 
--{1, 3, 6-8}
++{1, 3, 6-8}
 
 ```js +{1, 3, 6-8}
 const getStringLength = (str) => str.length;

--- a/test/fixtures/addedLines.md
+++ b/test/fixtures/addedLines.md
@@ -1,0 +1,15 @@
+## Added lines
+
+-{1, 3, 6-8}
+
+```js +{1, 3, 6-8}
+const getStringLength = (str) => str.length;
+
+const add = (a, b) => a + b;
+
+const divide = (a, b) => a / b;
+
+const subtract = (a, b) => a - b;
+
+const multiply = (a, b) => a * b;
+```

--- a/test/fixtures/removedLines.md
+++ b/test/fixtures/removedLines.md
@@ -1,0 +1,15 @@
+## Removed lines
+
+-{1, 3, 6-8}
+
+```js -{1, 3, 6-8}
+const getStringLength = (str) => str.length;
+
+const add = (a, b) => a + b;
+
+const divide = (a, b) => a / b;
+
+const subtract = (a, b) => a - b;
+
+const multiply = (a, b) => a * b;
+```

--- a/test/results/addedLines.html
+++ b/test/results/addedLines.html
@@ -1,0 +1,51 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  [data-highlighted-line], [data-highlighted-chars] {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>[data-line]::before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+</style>
+<h2>Added lines</h2>
+<p>-{1, 3, 6-8}</p>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    class="github-dark"
+    style="background-color: #24292e"
+    tabindex="0"
+    data-language="js"
+    data-theme="default"
+  ><code data-language="js" data-theme="default" style="display: grid;"><span data-line="" data-added-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">getStringLength</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">str</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> str.</span><span style="color: #79B8FF">length</span><span style="color: #E1E4E8">;</span></span>
+<span data-line=""> </span>
+<span data-line="" data-added-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">add</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">+</span><span style="color: #E1E4E8"> b;</span></span>
+<span data-line=""> </span>
+<span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">divide</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">/</span><span style="color: #E1E4E8"> b;</span></span>
+<span data-line="" data-added-line=""> </span>
+<span data-line="" data-added-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">subtract</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">-</span><span style="color: #E1E4E8"> b;</span></span>
+<span data-line="" data-added-line=""> </span>
+<span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">multiply</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">*</span><span style="color: #E1E4E8"> b;</span></span></code></pre>
+</div>

--- a/test/results/addedLines.html
+++ b/test/results/addedLines.html
@@ -31,7 +31,7 @@
   }
 </style>
 <h2>Added lines</h2>
-<p>-{1, 3, 6-8}</p>
+<p>+{1, 3, 6-8}</p>
 <div data-rehype-pretty-code-fragment="">
   <pre
     class="github-dark"

--- a/test/results/removedLines.html
+++ b/test/results/removedLines.html
@@ -1,0 +1,51 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  [data-highlighted-line], [data-highlighted-chars] {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>[data-line]::before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+</style>
+<h2>Removed lines</h2>
+<p>-{1, 3, 6-8}</p>
+<div data-rehype-pretty-code-fragment="">
+  <pre
+    class="github-dark"
+    style="background-color: #24292e"
+    tabindex="0"
+    data-language="js"
+    data-theme="default"
+  ><code data-language="js" data-theme="default" style="display: grid;"><span data-line="" data-removed-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">getStringLength</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">str</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> str.</span><span style="color: #79B8FF">length</span><span style="color: #E1E4E8">;</span></span>
+<span data-line=""> </span>
+<span data-line="" data-removed-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">add</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">+</span><span style="color: #E1E4E8"> b;</span></span>
+<span data-line=""> </span>
+<span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">divide</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">/</span><span style="color: #E1E4E8"> b;</span></span>
+<span data-line="" data-removed-line=""> </span>
+<span data-line="" data-removed-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">subtract</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">-</span><span style="color: #E1E4E8"> b;</span></span>
+<span data-line="" data-removed-line=""> </span>
+<span data-line=""><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0">multiply</span><span style="color: #E1E4E8"> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> (</span><span style="color: #FFAB70">a</span><span style="color: #E1E4E8">, </span><span style="color: #FFAB70">b</span><span style="color: #E1E4E8">) </span><span style="color: #F97583">=></span><span style="color: #E1E4E8"> a </span><span style="color: #F97583">*</span><span style="color: #E1E4E8"> b;</span></span></code></pre>
+</div>

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -38,6 +38,16 @@ pre > code {
   @apply border-l-blue-400;
 }
 
+[data-added-line] {
+  background: rgba(200, 255, 200, 0.1);
+  @apply border-l-green-400;
+}
+
+[data-removed-line] {
+  background: rgba(255, 200, 200, 0.1);
+  @apply border-l-red-400;
+}
+
 [data-highlighted-chars] {
   @apply bg-zinc-600/50 rounded;
   box-shadow: 0 0 0 4px rgb(82 82 91 / 0.5);

--- a/website/src/app/index.mdx
+++ b/website/src/app/index.mdx
@@ -274,6 +274,26 @@ Place a numeric range inside `{}`.
 ```
 ````
 
+To highlight diff lines, you can preface ranges with `+` or `-`.
+
+````md
+```js +{1-3} -{4-6}
+
+```
+````
+
+```css +{1-4} -{6-9}
+[data-added-line] {
+  background: rgba(200, 255, 200, 0.1);
+  @apply border-l-green-400;
+}
+
+[data-removed-line] {
+  background: rgba(255, 200, 200, 0.1);
+  @apply border-l-red-400;
+}
+```
+
 The line `<span>{:html}` receives a `data-highlighted-line` attribute to style
 via CSS.
 


### PR DESCRIPTION
Expands upon the highlighting system to allow for diff style highlights. This PR allows tagging `+{numeric range}` and `-{numeric range}` and parses them into `data-added-line` and `data-removed-line` properties.

I did not add new API hooks for these; I'm guessing that will be desired, but wanted to check first. I wasn't sure if they should be new methods or if `onVisitHighlightedLine` was preferred.

I'm having difficulties getting the website to run, so I'm unsure if my changes there work.

Fixes #118 