### PR TITLE
chore: upgrade deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "jest-file-snapshot": "^0.5.0",
         "jest-mock": "^29.5.0",
         "mdast-util-to-hast": "^12.1.0",
-        "prettier": "^2.8.8",
+        "prettier": "^3.1.0",
         "remark": "^14.0.2",
         "rollup": "^2.60.2",
         "rome": "12.1.3",
@@ -8920,15 +8920,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -17111,9 +17111,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true
     },
     "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "rehype-pretty-code",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rehype-pretty-code",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
+        "@types/hast": "^3.0.3",
         "hash-obj": "^4.0.0",
-        "hast-util-to-string": "^2.0.0",
+        "hast-util-to-string": "^3.0.0",
         "parse-numeric-range": "^1.3.0",
-        "rehype-parse": "^8.0.3",
-        "unified": "^10.1.2",
-        "unist-util-visit": "^4.0.0"
+        "rehype-parse": "^9.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.5",
@@ -23,7 +24,6 @@
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.1",
-        "@types/hast": "^2.0.0",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
@@ -3372,9 +3372,9 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -3439,10 +3439,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
       "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
-    },
-    "node_modules/@types/parse5": {
-      "version": "6.0.3",
-      "license": "MIT"
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
@@ -4855,7 +4851,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4874,6 +4869,18 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -4952,6 +4959,17 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5949,18 +5967,124 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-from-parse5": {
-      "version": "7.1.0",
-      "license": "MIT",
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.1.tgz",
+      "integrity": "sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "@types/parse5": "^6.0.0",
-        "@types/unist": "^2.0.0",
-        "hastscript": "^7.0.0",
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/hast-util-from-html/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
+      "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^8.0.0",
         "property-information": "^6.0.0",
-        "vfile": "^5.0.0",
-        "vfile-location": "^4.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
         "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/hast-util-from-parse5/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5980,11 +6104,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-parse-selector": {
-      "version": "3.1.0",
-      "license": "MIT",
+    "node_modules/hast-util-is-element/node_modules/@types/hast": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+      "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
+      "dev": true,
       "dependencies": {
-        "@types/hast": "^2.0.0"
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6012,11 +6146,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-string": {
-      "version": "2.0.0",
-      "license": "MIT",
+    "node_modules/hast-util-to-html/node_modules/@types/hast": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+      "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
+      "dev": true,
       "dependencies": {
-        "@types/hast": "^2.0.0"
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.0.tgz",
+      "integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6033,12 +6177,13 @@
       }
     },
     "node_modules/hastscript": {
-      "version": "7.0.2",
-      "license": "MIT",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
+        "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^3.0.0",
+        "hast-util-parse-selector": "^4.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0"
       },
@@ -6225,6 +6370,7 @@
     },
     "node_modules/is-buffer": {
       "version": "2.0.5",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7635,6 +7781,44 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-hast/node_modules/@types/hast": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+      "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-markdown": {
       "version": "1.3.0",
       "dev": true,
@@ -7647,6 +7831,35 @@
         "micromark-util-decode-string": "^1.0.0",
         "unist-util-visit": "^4.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8495,8 +8708,15 @@
       "license": "ISC"
     },
     "node_modules/parse5": {
-      "version": "6.0.1",
-      "license": "MIT"
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -8942,13 +9162,13 @@
       }
     },
     "node_modules/rehype-parse": {
-      "version": "8.0.4",
-      "license": "MIT",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.0.tgz",
+      "integrity": "sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "hast-util-from-parse5": "^7.0.0",
-        "parse5": "^6.0.0",
-        "unified": "^10.0.0"
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8984,6 +9204,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-parse/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-stringify": {
       "version": "10.0.2",
       "dev": true,
@@ -8992,6 +9231,44 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.0.0",
         "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10008,17 +10285,61 @@
       }
     },
     "node_modules/unified": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+      "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
       "dependencies": {
-        "@types/unist": "^2.0.0",
+        "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
+        "devlop": "^1.0.0",
         "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
-        "vfile": "^5.0.0"
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/unified/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10048,6 +10369,7 @@
     },
     "node_modules/unist-util-is": {
       "version": "5.1.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10068,6 +10390,7 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0"
@@ -10078,12 +10401,13 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "4.1.0",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.0.0"
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10091,11 +10415,46 @@
       }
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "5.1.0",
-      "license": "MIT",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/unist-util-visit/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10181,6 +10540,7 @@
     },
     "node_modules/vfile": {
       "version": "5.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -10194,11 +10554,56 @@
       }
     },
     "node_modules/vfile-location": {
-      "version": "4.0.1",
-      "license": "MIT",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.2.tgz",
+      "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "vfile": "^5.0.0"
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/vfile-location/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10207,6 +10612,7 @@
     },
     "node_modules/vfile-message": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -10416,7 +10822,8 @@
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12924,9 +13331,9 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
       "requires": {
         "@types/unist": "*"
       }
@@ -12985,9 +13392,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
       "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
-    },
-    "@types/parse5": {
-      "version": "6.0.3"
     },
     "@types/prettier": {
       "version": "2.7.3",
@@ -13949,8 +14353,7 @@
     "dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "destr": {
       "version": "1.2.2",
@@ -13964,6 +14367,14 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "peer": true
+    },
+    "devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "requires": {
+        "dequal": "^2.0.0"
+      }
     },
     "diff": {
       "version": "5.0.0",
@@ -14014,6 +14425,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "peer": true
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -14698,17 +15114,100 @@
         "function-bind": "^1.1.2"
       }
     },
-    "hast-util-from-parse5": {
-      "version": "7.1.0",
+    "hast-util-from-html": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.1.tgz",
+      "integrity": "sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==",
       "requires": {
-        "@types/hast": "^2.0.0",
-        "@types/parse5": "^6.0.0",
-        "@types/unist": "^2.0.0",
-        "hastscript": "^7.0.0",
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "vfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+          "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0",
+            "vfile-message": "^4.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+          "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          }
+        }
+      }
+    },
+    "hast-util-from-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
+      "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^8.0.0",
         "property-information": "^6.0.0",
-        "vfile": "^5.0.0",
-        "vfile-location": "^4.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
         "web-namespaces": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "vfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+          "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0",
+            "vfile-message": "^4.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+          "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          }
+        }
       }
     },
     "hast-util-is-element": {
@@ -14717,12 +15216,25 @@
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/hast": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+          "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2"
+          }
+        }
       }
     },
     "hast-util-parse-selector": {
-      "version": "3.1.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "requires": {
-        "@types/hast": "^2.0.0"
+        "@types/hast": "^3.0.0"
       }
     },
     "hast-util-to-html": {
@@ -14739,12 +15251,25 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.2",
         "unist-util-is": "^5.0.0"
+      },
+      "dependencies": {
+        "@types/hast": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+          "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2"
+          }
+        }
       }
     },
     "hast-util-to-string": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.0.tgz",
+      "integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
       "requires": {
-        "@types/hast": "^2.0.0"
+        "@types/hast": "^3.0.0"
       }
     },
     "hast-util-whitespace": {
@@ -14752,11 +15277,13 @@
       "dev": true
     },
     "hastscript": {
-      "version": "7.0.2",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
       "requires": {
-        "@types/hast": "^2.0.0",
+        "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^3.0.0",
+        "hast-util-parse-selector": "^4.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0"
       }
@@ -14880,7 +15407,8 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.7",
@@ -15898,6 +16426,38 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/hast": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+          "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        }
       }
     },
     "mdast-util-to-markdown": {
@@ -15911,6 +16471,29 @@
         "micromark-util-decode-string": "^1.0.0",
         "unist-util-visit": "^4.0.0",
         "zwitch": "^2.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        }
       }
     },
     "mdast-util-to-string": {
@@ -16386,7 +16969,12 @@
       "version": "1.3.0"
     },
     "parse5": {
-      "version": "6.0.1"
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "requires": {
+        "entities": "^4.4.0"
+      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -16691,12 +17279,13 @@
       }
     },
     "rehype-parse": {
-      "version": "8.0.4",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.0.tgz",
+      "integrity": "sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==",
       "requires": {
-        "@types/hast": "^2.0.0",
-        "hast-util-from-parse5": "^7.0.0",
-        "parse5": "^6.0.0",
-        "unified": "^10.0.0"
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
       }
     },
     "remark": {
@@ -16707,6 +17296,23 @@
         "remark-parse": "^10.0.0",
         "remark-stringify": "^10.0.0",
         "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        }
       }
     },
     "remark-parse": {
@@ -16716,6 +17322,23 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
         "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        }
       }
     },
     "remark-stringify": {
@@ -16725,6 +17348,23 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.0.0",
         "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        }
       }
     },
     "require-directory": {
@@ -17416,17 +18056,51 @@
       "dev": true
     },
     "unified": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+      "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
       "requires": {
-        "@types/unist": "^2.0.0",
+        "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
+        "devlop": "^1.0.0",
         "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
-        "vfile": "^5.0.0"
+        "vfile": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "vfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+          "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0",
+            "vfile-message": "^4.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+          "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          }
+        }
       }
     },
     "unist-builder": {
@@ -17441,7 +18115,8 @@
       "dev": true
     },
     "unist-util-is": {
-      "version": "5.1.1"
+      "version": "5.1.1",
+      "dev": true
     },
     "unist-util-position": {
       "version": "4.0.2",
@@ -17452,23 +18127,58 @@
     },
     "unist-util-stringify-position": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0"
       }
     },
     "unist-util-visit": {
-      "version": "4.1.0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.0.0"
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        }
       }
     },
     "unist-util-visit-parents": {
-      "version": "5.1.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        }
       }
     },
     "update-browserslist-db": {
@@ -17516,6 +18226,7 @@
     },
     "vfile": {
       "version": "5.3.2",
+      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -17524,14 +18235,51 @@
       }
     },
     "vfile-location": {
-      "version": "4.0.1",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.2.tgz",
+      "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "vfile": "^5.0.0"
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "vfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+          "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0",
+            "vfile-message": "^4.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+          "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          }
+        }
       }
     },
     "vfile-message": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -17637,7 +18385,9 @@
       }
     },
     "web-namespaces": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jest-file-snapshot": "^0.5.0",
     "jest-mock": "^29.5.0",
     "mdast-util-to-hast": "^12.1.0",
-    "prettier": "^2.8.8",
+    "prettier": "^3.1.0",
     "remark": "^14.0.2",
     "rollup": "^2.60.2",
     "rome": "12.1.3",

--- a/package.json
+++ b/package.json
@@ -73,15 +73,15 @@
     "ts-jest": "^29.1.0",
     "typescript": "^4.9.5",
     "vite": "^4.3.9",
-    "vitest": "^0.32.2",
-    "@types/hast": "^2.0.0"
+    "vitest": "^0.32.2"
   },
   "dependencies": {
+    "@types/hast": "^3.0.3",
     "hash-obj": "^4.0.0",
+    "hast-util-to-string": "^3.0.0",
     "parse-numeric-range": "^1.3.0",
-    "hast-util-to-string": "^2.0.0",
-    "unist-util-visit": "^4.0.0",
-    "rehype-parse": "^8.0.3",
-    "unified": "^10.1.2"
+    "rehype-parse": "^9.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
   }
 }

--- a/src/chars/charsHighlighter.ts
+++ b/src/chars/charsHighlighter.ts
@@ -21,8 +21,8 @@ export function charsHighlighter(
   options: CharsHighlighterOptions,
   onVisitHighlightedChars?: (
     element: CharsElement,
-    id: string | undefined
-  ) => void
+    id: string | undefined,
+  ) => void,
 ) {
   const { ranges = [] } = options;
   const textContent = toString(element);
@@ -46,7 +46,7 @@ export function charsHighlighter(
           element,
           chars,
           startIndex,
-          ignoreChars
+          ignoreChars,
         );
 
         // maybe throw / notify due to failure here
@@ -57,7 +57,7 @@ export function charsHighlighter(
           elementsToWrap,
           options,
           ignoreChars,
-          onVisitHighlightedChars
+          onVisitHighlightedChars,
         );
 
         // re-start from the 'last' node (the chars or part of them may exist
@@ -65,7 +65,7 @@ export function charsHighlighter(
         // account for possible extra nodes added from split with - 2
         startIndex = Math.max(
           elementsToWrap[elementsToWrap.length - 1].index - 2,
-          0
+          0,
         );
 
         textContent = element.children

--- a/src/chars/getElementsToHighlight.ts
+++ b/src/chars/getElementsToHighlight.ts
@@ -11,7 +11,7 @@ export function getElementsToHighlight(
   element: Element,
   chars: string,
   startIndex = 0,
-  ignoreChars = false
+  ignoreChars = false,
 ): Array<{ element: Element; index: number }> {
   const toWrap = [];
   let charsSoFar = '';
@@ -34,7 +34,7 @@ export function getElementsToHighlight(
         // ignore any previously matched chars within
         hasOwnProperty(
           maybeElement.properties ?? {},
-          'rehype-pretty-code-visited'
+          'rehype-pretty-code-visited',
         )
       ) {
         continue;

--- a/src/chars/wrapHighlightedChars.ts
+++ b/src/chars/wrapHighlightedChars.ts
@@ -10,8 +10,8 @@ export function wrapHighlightedChars(
   ignoreWord: boolean,
   onVisitHighlightedChars?: (
     element: CharsElement,
-    id: string | undefined
-  ) => void
+    id: string | undefined,
+  ) => void,
 ) {
   if (!elementsToWrap || elementsToWrap.length === 0) {
     return;
@@ -35,7 +35,7 @@ export function wrapHighlightedChars(
         tagName: 'span',
         properties: { 'data-highlighted-chars-wrapper': '' },
         children: elementsToWrap.map(({ element }) => element),
-      }
+      },
     );
 
     const element = parentElement.children[elementsToWrap[0].index];

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function toFragment(
     lineNumbersMaxDigits = 1,
     onVisitTitle,
     onVisitCaption,
-  }: ToFragmentProps
+  }: ToFragmentProps,
 ) {
   element.tagName = inline ? 'span' : 'div';
   // User can replace this with a real Fragment at runtime
@@ -143,7 +143,7 @@ const globalHighlighterCache = new Map<
 const hastParser = unified().use(rehypeParse, { fragment: true });
 
 export default function rehypePrettyCode(
-  options: Options = {}
+  options: Options = {},
 ): void | Transformer<Root, Root> {
   const {
     grid = true,
@@ -169,7 +169,7 @@ export default function rehypePrettyCode(
       onVisitHighlightedChars,
       getHighlighter,
     },
-    { algorithm: 'sha1' }
+    { algorithm: 'sha1' },
   );
   let highlighterCache = globalHighlighterCache.get(optionsHash);
   if (!highlighterCache) {
@@ -242,12 +242,13 @@ export default function rehypePrettyCode(
             const color =
               highlighter
                 .getTheme()
-                .settings.find(({ scope }: { scope?: string[] }) =>
-                  scope?.includes(tokensMap[meta.slice(1)] ?? meta.slice(1))
+                .settings.find(
+                  ({ scope }: { scope?: string[] }) =>
+                    scope?.includes(tokensMap[meta.slice(1)] ?? meta.slice(1)),
                 )?.settings.foreground ?? 'inherit';
 
             trees[mode] = hastParser.parse(
-              `<pre><code><span style="color:${color}">${strippedValue}</span></code></pre>`
+              `<pre><code><span style="color:${color}">${strippedValue}</span></code></pre>`,
             );
           } else {
             let html;
@@ -356,7 +357,7 @@ export default function rehypePrettyCode(
           } catch (e) {
             // Fallback to plain text if a language has not been registered
             trees[mode] = hastParser.parse(
-              highlighter.codeToHtml(strippedValue, 'txt')
+              highlighter.codeToHtml(strippedValue, 'txt'),
             );
           }
         }
@@ -380,7 +381,7 @@ export default function rehypePrettyCode(
               }
 
               const lineNumbersStartAtMatch = reverseString(meta).match(
-                /(?:\}(\d+){)?srebmuNeniLwohs(?!(.*)(\/))/
+                /(?:\}(\d+){)?srebmuNeniLwohs(?!(.*)(\/))/,
               );
               const startNumberString = lineNumbersStartAtMatch?.[1];
               if (startNumberString) {
@@ -403,7 +404,7 @@ export default function rehypePrettyCode(
               }
 
               const className = element.properties.className.filter(
-                (c) => c !== 'line'
+                (c) => c !== 'line',
               );
               element.properties.className =
                 className.length > 0 ? className : undefined;
@@ -422,7 +423,7 @@ export default function rehypePrettyCode(
                 element,
                 words,
                 wordOptions,
-                onVisitHighlightedChars
+                onVisitHighlightedChars,
               );
 
               lineNumbersMaxDigits++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,11 @@ function toFragment(
       const code = pre.children[0];
 
       // Remove class="shiki"
-      if (Array.isArray(pre.properties?.className) && pre.properties?.className.includes('shiki')) {
-        const className = pre.properties.className.filter(c => c !== 'shiki');
+      if (
+        Array.isArray(pre.properties?.className) &&
+        pre.properties?.className.includes('shiki')
+      ) {
+        const className = pre.properties.className.filter((c) => c !== 'shiki');
         pre.properties.className = className.length > 0 ? className : undefined;
       }
 
@@ -399,8 +402,11 @@ export default function rehypePrettyCode(
                 element.children = [{ type: 'text', value: ' ' }];
               }
 
-              const className = element.properties.className.filter(c => c !== 'line');
-              element.properties.className = className.length > 0 ? className : undefined;
+              const className = element.properties.className.filter(
+                (c) => c !== 'line'
+              );
+              element.properties.className =
+                className.length > 0 ? className : undefined;
               element.properties['data-line'] = '';
               onVisitLine?.(element as LineElement);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export function isShikiTheme(value: any): value is IShikiTheme {
 }
 
 export function isElement(
-  value: ElementContent | Element | Root | RootContent | null | undefined
+  value: ElementContent | Element | Root | RootContent | null | undefined,
 ): value is Element {
   return value ? value.type === 'element' : false;
 }
@@ -18,7 +18,7 @@ export function isText(value: ElementContent | null): value is Text {
 
 export function hasOwnProperty(
   object: Record<string, unknown>,
-  string: string
+  string: string,
 ) {
   return {}.hasOwnProperty.call(object, string);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export function isShikiTheme(value: any): value is IShikiTheme {
 }
 
 export function isElement(
-  value: ElementContent | Element | Root | RootContent | null
+  value: ElementContent | Element | Root | RootContent | null | undefined
 ): value is Element {
   return value ? value.type === 'element' : false;
 }

--- a/test/chars-highlighter-playground/index.html
+++ b/test/chars-highlighter-playground/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/test/chars-highlighter-playground/src/App.jsx
+++ b/test/chars-highlighter-playground/src/App.jsx
@@ -70,8 +70,8 @@ function App() {
         highlighter.current.codeToHtml(
           editorRef.current.getDoc().getValue('\n'),
           mode,
-          DEFAULT_THEME
-        )
+          DEFAULT_THEME,
+        ),
       );
     }
     if (highlighter.current) {
@@ -82,8 +82,8 @@ function App() {
             plugins: [htmlParser],
           }),
           'html',
-          DEFAULT_THEME
-        )
+          DEFAULT_THEME,
+        ),
       );
     }
   }, [mode]);
@@ -94,7 +94,7 @@ function App() {
         container.innerHTML = highlighter.current.codeToHtml(
           editorRef.current.getDoc().getValue('\n'),
           mode,
-          DEFAULT_THEME
+          DEFAULT_THEME,
         );
       }
       let options = {
@@ -114,11 +114,11 @@ function App() {
           `Something went wrong with highlighting!
           
           expect: ${container.textContent}
-          got: ${value}`
+          got: ${value}`,
         );
       }
     },
-    [word, wordNumbers, value, mode]
+    [word, wordNumbers, value, mode],
   );
 
   React.useEffect(() => {

--- a/test/chars-highlighter-playground/src/main.jsx
+++ b/test/chars-highlighter-playground/src/main.jsx
@@ -7,5 +7,5 @@ ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -29,22 +29,22 @@ const getTheme = (multiple) => {
   const singleTheme = JSON.parse(
     readFileSync(
       join(__dirname, '../node_modules/shiki/themes/github-dark.json'),
-      'utf-8'
-    )
+      'utf-8',
+    ),
   );
 
   const multipleTheme = {
     dark: JSON.parse(
       readFileSync(
         join(__dirname, '../node_modules/shiki/themes/github-dark.json'),
-        'utf-8'
-      )
+        'utf-8',
+      ),
     ),
     light: JSON.parse(
       readFileSync(
         join(__dirname, '../node_modules/shiki/themes/github-light.json'),
-        'utf-8'
-      )
+        'utf-8',
+      ),
     ),
   };
   return multiple ? multipleTheme : singleTheme;
@@ -127,7 +127,7 @@ describe('Single theme', () => {
       const { htmlString, resultHTMLPath } = await runFixture(
         fixture,
         fixtureName,
-        getHighlighter
+        getHighlighter,
       );
 
       expect(defaultStyle + htmlString).toMatchFile(resultHTMLPath);
@@ -151,7 +151,7 @@ describe('Multiple theme', () => {
       const { htmlString, resultHTMLPath } = await runFixture(
         fixture,
         fixtureName,
-        getHighlighter
+        getHighlighter,
       );
 
       expect(defaultStyle + htmlString).toMatchFile(resultHTMLPath);


### PR DESCRIPTION
Fixes #117 
Fixes #123

Seems like it's a build error if they're using `unified@^11`, while this repo uses `unified@^10`, as when I downgrade to `unified@^10` in the example repo, the error goes away for the `rehypePrettyCode` call.