### PR TITLE
fix: collapsing lines with plaintext lang with grid true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type { CharsHighlighterOptions } from './types';
 import type { Highlighter, CodeToHastOptions } from 'shikiji';
 import type { Transformer } from 'unified';
 import { visit } from 'unist-util-visit';
+import { toString } from 'hast-util-to-string';
 import rangeParser from 'parse-numeric-range';
 import { getHighlighter as defaultGetHighlighter } from 'shikiji';
 import { unified } from 'unified';
@@ -442,7 +443,7 @@ export default function rehypePrettyCode(
             Array.isArray(element.properties?.className) &&
             element.properties?.className?.[0] === 'line'
           ) {
-            if (grid && element.children.length === 0) {
+            if (grid && toString(element) === '') {
               element.children = [{ type: 'text', value: ' ' }];
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import type { CharsHighlighterOptions } from './types';
 import type { Highlighter, CodeToHastOptions } from 'shikiji';
 import type { Transformer } from 'unified';
 import { visit } from 'unist-util-visit';
-import { toString } from 'hast-util-to-string';
+import { toString as hastToString } from 'hast-util-to-string';
 import rangeParser from 'parse-numeric-range';
 import { getHighlighter as defaultGetHighlighter } from 'shikiji';
 import { unified } from 'unified';
@@ -443,7 +443,7 @@ export default function rehypePrettyCode(
             Array.isArray(element.properties?.className) &&
             element.properties?.className?.[0] === 'line'
           ) {
-            if (grid && toString(element) === '') {
+            if (grid && hastToString(element) === '') {
               element.children = [{ type: 'text', value: ' ' }];
             }
 

--- a/test/fixtures/unknownLanguage.md
+++ b/test/fixtures/unknownLanguage.md
@@ -1,5 +1,7 @@
 # Unknown language
 
-```console
-test
+```abcdefg
+line 1
+
+line 2
 ```

--- a/test/results/unknownLanguage.html
+++ b/test/results/unknownLanguage.html
@@ -56,7 +56,9 @@
   <pre
     style="background-color: #24292e; color: #e1e4e8"
     tabindex="0"
-    data-language="console"
+    data-language="abcdefg"
     data-theme="github-dark"
-  ><code data-language="console" data-theme="github-dark" style="display: grid;"><span data-line=""><span style="color:#79B8FF">test</span></span></code></pre>
+  ><code data-language="abcdefg" data-theme="github-dark" style="display: grid;"><span data-line=""><span>line 1</span></span>
+<span data-line=""> </span>
+<span data-line=""><span>line 2</span></span></code></pre>
 </figure>


### PR DESCRIPTION
`plaintext` language renders another `<span>` so the children empty check fails. `toString(node)` being empty works for both

Fix #157
