### PR TITLE
fix: export types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   replaceLineClass,
   getLineId,
 } from './utils';
+export type { Options, LineElement, CharsElement, Theme } from './types';
 
 interface ApplyProps {
   tree: Root;


### PR DESCRIPTION
Fixes #160

Ignores `CharsHighlighterOptions`, as it's currently internal.